### PR TITLE
fix: double spaces

### DIFF
--- a/src/copyrightinserter.ts
+++ b/src/copyrightinserter.ts
@@ -78,11 +78,11 @@ the Free Software Foundation, either version 3 of the License, or
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.`],
+along with this program. If not, see <https://www.gnu.org/licenses/>.`],
 
         ['agpl3', (holder: string, year:string) =>
 `Copyright (C) ${year} ${holder}


### PR DESCRIPTION
Removed two Typo: double spaces in Licence notes