### PR TITLE
Add support for user-defined license text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,13 @@
 - Add `MPL 2.0` license to the list of the supported licenses. 
 
 ## [1.0.14]
-- Remove extra spaces in the text of licenses
+- Remove extra spaces in the text of licenses.
 
 ## [1.0.15]
-- Fix the error to address a use case when the language is defined but lacks configuration data
+- Fix the error to address a use case when the language is defined but lacks configuration data.
+
+## [1.0.17]
+(skipping version 1.0.16 as experimental)
+
+- Enforce validation for configuration parameters.
+- Add support of license with a user provided text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,6 @@
 ## [1.0.15]
 - Fix the error to address a use case when the language is defined but lacks configuration data.
 
-## [1.0.17]
-(skipping version 1.0.16 as experimental)
-
-- Enforce validation for configuration parameters.
+## [1.1.0]
 - Add support of license with a user provided text.
+- Enforce validation for configuration parameters.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ The Copyright Inserter is a VS Code extension that adds a copyright and license 
 The extension supports the following licenses:
 
 **Copyright**
+
 - [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [MIT](https://opensource.org/licenses/MIT)
 - [BSD](http://www.linfo.org/bsdlicense.html)
 
 **Copyleft**
+
 - [GPL 3](https://www.gnu.org/licenses/gpl-3.0.en.html)
 - [Affero GPL 3](https://www.gnu.org/licenses/agpl-3.0.en.html)
 - [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/)
@@ -27,13 +29,12 @@ The extension can be invoked by typing `insert header` or `Copyright: insert hea
 
 ![Insert copyright header](resources/animation.gif)
 
-
 ## Extension Settings
 
 This extension adds the following settings into `Extensions` section under `Copyright Inserter`:
 
-* `copyrightInserter.holder`: a string describing the copyright holder. Default value is `Google LLC`
-* `copyrightInserter.license`: one of the following
+- `copyrightInserter.holder`: a string describing the copyright holder. Maximum length is 128 symbols. Default value is `Google LLC`
+- `copyrightInserter.license`: one of the following
   - "Apache 2.0 `apache`" for Apache License, Version 2.0
   - "Affero GPL 3 `agpl3`" for GNU Affero General Public License version 3
   - "BSD `bsd`" for BSD-style license
@@ -41,9 +42,9 @@ This extension adds the following settings into `Extensions` section under `Copy
   - "MIT `mit`" for MIT license
   - "MPL 2 `mpl2`" for Mozilla Public License version 2
   - "User defined `user`" for a license text that is provided by a user
-* `copyrightInserter.year`: a string describing the copyright year. Default value is empty string. If the string is empty, the current year will be used.
-* `copyrightInserter.useLineComment`: a boolean flag to describe selection between block and line comments. Default is `false`.
-* `copyrightInserter.userText`: 
+- `copyrightInserter.year`: a four digit copyright year or an empty string. If the string is empty, the current year will be used. Default value is empty string.
+- `copyrightInserter.useLineComment`: a boolean flag to describe selection between block and line comments. Default is `false`.
+- `copyrightInserter.userText`: A text of the user-defined license. It should use placeholders `${holder}` to include the copyright holder and `${year}` to include the copyright year. The maximum length is 2048 symbols. The `copyrightInserter.license` should be set to `user` in order to use the user-defined text for the license.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,17 @@ The extension can be invoked by typing `insert header` or `Copyright: insert hea
 This extension adds the following settings into `Extensions` section under `Copyright Inserter`:
 
 * `copyrightInserter.holder`: a string describing the copyright holder. Default value is `Google LLC`
-* `copyrightInserter.license`: one of the following literals that define the copyright license: `apache` for Apache 2.0, `bsd` for BSD, `mit` for MIT, `gpl3` for GPL version 3 and `agpl3` for Affero GPL version 3. Default value is `apache`.
+* `copyrightInserter.license`: one of the following
+  - "Apache 2.0 `apache`" for Apache License, Version 2.0
+  - "Affero GPL 3 `agpl3`" for GNU Affero General Public License version 3
+  - "BSD `bsd`" for BSD-style license
+  - "GPL 3 `gpl3" for GLP version 3
+  - "MIT `mit`" for MIT license
+  - "MPL 2 `mpl2`" for Mozilla Public License version 2
+  - "User defined `user`" for a license text that is provided by a user
 * `copyrightInserter.year`: a string describing the copyright year. Default value is empty string. If the string is empty, the current year will be used.
 * `copyrightInserter.useLineComment`: a boolean flag to describe selection between block and line comments. Default is `false`.
+* `copyrightInserter.userText`: 
 
 ## Known Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "copyright-inserter",
-	"version": "1.0.17",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "copyright-inserter",
-			"version": "1.0.17",
+			"version": "1.1.0",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"jsonc-parser": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "copyright-inserter",
-	"version": "1.0.15",
+	"version": "1.0.16",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "copyright-inserter",
-			"version": "1.0.15",
+			"version": "1.0.16",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"jsonc-parser": "^3.0.0"
@@ -18,7 +18,7 @@
 				"typescript": "^3.3.1"
 			},
 			"engines": {
-				"vscode": "^1.40.0"
+				"vscode": "^1.80.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -265,10 +265,11 @@
 			"integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -328,10 +329,11 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
 			}
@@ -620,9 +622,9 @@
 			"integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
@@ -674,9 +676,9 @@
 			}
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true
 		},
 		"sprintf-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "copyright-inserter",
-	"version": "1.0.16",
+	"version": "1.0.17",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "copyright-inserter",
-			"version": "1.0.16",
+			"version": "1.0.17",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"jsonc-parser": "^3.0.0"
@@ -18,7 +18,7 @@
 				"typescript": "^3.3.1"
 			},
 			"engines": {
-				"vscode": "^1.80.0"
+				"vscode": "^1.40.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "minherz",
 	"displayName": "Copyright Inserter",
 	"description": "Inserts copyright header of the selected license into active editor",
-	"version": "1.0.16",
+	"version": "1.0.17",
 	"icon": "resources/copyright.jpg",
 	"license": "SEE LICENSE IN LICENSE",
 	"repository": {
@@ -14,7 +14,7 @@
 		"url": "https://github.com/minherz/copyright-inserter/issues"
 	},
 	"engines": {
-		"vscode": "^1.80.0"
+		"vscode": "^1.40.0"
 	},
 	"extensionKind": [
 		"ui",
@@ -49,11 +49,12 @@
 						"gpl3",
 						"mit",
 						"mpl2",
-						"custom"
+						"user"
 					],
 					"enumItemLabels": [
 						"Apache 2.0",
 						"Affero GPL 3",
+						"BSD",
 						"GPL 3",
 						"MIT",
 						"MPL 2",
@@ -89,14 +90,11 @@
 					"default": "",
 					"description": "A short prefix string to insert into all copyright lines before the text (except for first and last lines)"
 				},
-				"copyrightInserter.customText": {
+				"copyrightInserter.userText": {
 					"order": 4,
-					"type": [
-						"string",
-						"null"
-					],
+					"type": "string",
 					"default": "",
-					"description": "Custom license text. Use '${year}' to mark the place for the copyright year and use '${holder}' to mark the place for the copyright holder."
+					"description": "User-defined license text. Use '${year}' to mark the place for the copyright year and use '${holder}' to mark the place for the copyright holder."
 				}
 			}
 		}
@@ -111,7 +109,7 @@
 	"devDependencies": {
 		"@types/node": "^10.12.21",
 		"@types/vscode": "^1.37.0",
-		"tslint": "^5.12.1",
+		"tslint": "^5.19.0",
 		"typescript": "^3.3.1"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "minherz",
 	"displayName": "Copyright Inserter",
 	"description": "Inserts copyright header of the selected license into active editor",
-	"version": "1.0.15",
+	"version": "1.0.16",
 	"icon": "resources/copyright.jpg",
 	"license": "SEE LICENSE IN LICENSE",
 	"repository": {
@@ -14,7 +14,7 @@
 		"url": "https://github.com/minherz/copyright-inserter/issues"
 	},
 	"engines": {
-		"vscode": "^1.40.0"
+		"vscode": "^1.80.0"
 	},
 	"extensionKind": [
 		"ui",
@@ -39,29 +39,64 @@
 			"title": "Copyright Inserter",
 			"properties": {
 				"copyrightInserter.license": {
+					"order": 1,
 					"type": "string",
 					"default": "apache",
-					"description": "A type of the license. Supported license types are 'apache', 'mit', 'bsd', 'gpl3', 'agpl3' and 'mpl2"
+					"enum": [
+						"apache",
+						"agpl3",
+						"bsd",
+						"gpl3",
+						"mit",
+						"mpl2",
+						"custom"
+					],
+					"enumItemLabels": [
+						"Apache 2.0",
+						"Affero GPL 3",
+						"GPL 3",
+						"MIT",
+						"MPL 2",
+						"User defined"
+					],
+					"description": "A type of the license. Select \"User defined\" if you want to provide your custom license text."
 				},
 				"copyrightInserter.holder": {
+					"order": 2,
 					"type": "string",
 					"default": "Google LLC",
+					"maxLength": 128,
 					"description": "Copyright holder"
 				},
 				"copyrightInserter.year": {
+					"order": 3,
 					"type": "string",
 					"default": "",
+					"pattern": "^$|^\\d{4}$",
+					"patternErrorMessage": "A year should be empty or composed of 4 digits",
 					"description": "Copyright year. If not defined, the current year is used"
 				},
 				"copyrightInserter.useLineComment": {
+					"order": 5,
 					"type": "boolean",
 					"default": false,
+					"maxLength": 2048,
 					"description": "When language supports block and line comments always enforces the use of line comment"
 				},
 				"copyrightInserter.linePrefix": {
+					"order": 6,
 					"type": "string",
 					"default": "",
-					"description": "A short prefix string to place in all copyright lines before the text (except for first and last lines)"
+					"description": "A short prefix string to insert into all copyright lines before the text (except for first and last lines)"
+				},
+				"copyrightInserter.customText": {
+					"order": 4,
+					"type": [
+						"string",
+						"null"
+					],
+					"default": "",
+					"description": "Custom license text. Use '${year}' to mark the place for the copyright year and use '${holder}' to mark the place for the copyright holder."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
 					"order": 5,
 					"type": "boolean",
 					"default": false,
-					"maxLength": 2048,
 					"description": "When language supports block and line comments always enforces the use of line comment"
 				},
 				"copyrightInserter.linePrefix": {
@@ -94,6 +93,7 @@
 					"order": 4,
 					"type": "string",
 					"default": "",
+					"maxLength": 2048,
 					"description": "User-defined license text. Use '${year}' to mark the place for the copyright year and use '${holder}' to mark the place for the copyright holder."
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "minherz",
 	"displayName": "Copyright Inserter",
 	"description": "Inserts copyright header of the selected license into active editor",
-	"version": "1.0.17",
+	"version": "1.1.0",
 	"icon": "resources/copyright.jpg",
 	"license": "SEE LICENSE IN LICENSE",
 	"repository": {

--- a/src/copyrightinserter.ts
+++ b/src/copyrightinserter.ts
@@ -119,8 +119,8 @@ file, You can obtain one at <https://mozilla.org/MPL/2.0/>.`],
         var licenseTemplate: LicenseTemplateFunction | undefined;
         let extensionConfig = this.getExtensionConfig();
 
-        if (extensionConfig.license === 'custom') {
-            licenseTemplate = (holder: string, year: string) => extensionConfig.customText;
+        if (extensionConfig.license === 'user') {
+            licenseTemplate = (holder: string, year: string) => eval('`' + extensionConfig.userText + '`');
         } else {
             licenseTemplate = this.CopyrightMap.get(extensionConfig.license);
         }
@@ -178,7 +178,7 @@ file, You can obtain one at <https://mozilla.org/MPL/2.0/>.`],
                 String(configView.get("copyrightInserter.holder")),
                 configView.get("copyrightInserter.year") || String((new Date()).getFullYear())
             ),
-            customText: (configView.get("copyrightInserter.customText") || ""),
+            userText: (configView.get("copyrightInserter.userText") || ""),
         };
     }
 
@@ -189,8 +189,11 @@ file, You can obtain one at <https://mozilla.org/MPL/2.0/>.`],
             return config;
         }
         for (const extension of vscode.extensions.all) {
-            if (extension.packageJSON.contributes && extension.packageJSON.contributes.languages) {
-                const data = extension.packageJSON.contributes.languages.find((it: any) => it.id === id && (!fileExt || it.extensions.indexOf(fileExt) >= 0));
+            const contributes = extension.packageJSON.contributes;
+            if (contributes && contributes.languages) {
+                const data = contributes.languages.find(
+                    (it: any) => it.id === id && (!fileExt || it.extensions.indexOf(fileExt) >= 0)
+                );
                 if (data && data.configuration) {
                     config = {
                         id: id,
@@ -211,14 +214,14 @@ file, You can obtain one at <https://mozilla.org/MPL/2.0/>.`],
 
         if (c!.blockComment) {
             let bcStart = this.escapeStringForRegexp(c!.blockComment[0]);
-            // treat "^" working over multiple lines, ignore casing and allow "." to match newline 
+            // "mis" -> match in multiple lines, ignore casing and allow "." to match newline 
             if (new RegExp(`^${bcStart}.*Copyright`, "mis").test(prefix)) {
                 return true;
             }
         }
         if (c!.lineComment) {
             let lc = this.escapeStringForRegexp(c!.lineComment);
-            // treat "^" working over multiple lines and ignore casing
+            // "mi" -> match in multiple lines, ignore casing
             if (new RegExp(`^${lc}.*Copyright`, "mi").test(prefix)) {
                 return true;
             }
@@ -317,7 +320,7 @@ type ExtensionConfiguration = {
     useLineComment: boolean,
     linePrefix: string,
     data: CopyrightData;
-    customText: string;
+    userText: string;
 };
 
 class CopyrightData {


### PR DESCRIPTION
Resolve #27.
Refactor definition of the extension's properties to enforce validations and use combo box to select the license type.
Update README to reflect changes to the properties.